### PR TITLE
Add tests for upload-service and asset-actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# Keycloak Theme Editor
+
+Visual editor for Keycloak login themes. Users style, preview, and export themes as deployable JARs without cloning or forking.
+
+Published to npm as `keycloak-theme-editor`. Deployed as a static site to keycloak-theme-editor.org via GitHub Pages.
+
+## Commands
+
+```bash
+npm run dev          # start Vite dev server (localhost:5173)
+npm run build        # tsc + vite build -> dist/
+npm run lint         # ESLint
+npm run test         # Vitest unit tests (watch mode)
+npm run test:run     # Vitest unit tests (single run)
+npm run test:e2e     # Playwright E2E (starts dev server automatically)
+npm run build:jar    # Maven build for tools/preview-renderer
+npm run build:cli    # tsup build for bin/cli.js
+```
+
+## Architecture
+
+Feature-based structure under `src/features/`:
+
+- `assets/` : file upload handling (fonts, images, backgrounds, logos, favicons)
+- `editor/` : core editor state (Zustand stores + actions + CodeMirror), QuickStart panel
+- `preview/` : iframe preview rendering, message passing between app and preview frame
+- `presets/` : preset management, theme path resolution
+- `theme-export/` : JAR and folder export/import, CSS assembly
+
+State management uses Zustand. The preview runs in an iframe and communicates via postMessage.
+
+Top-level components live in `src/components/` (Topbar, RightSidebar, ContextBar, SidebarPanel, ErrorBoundary).
+
+## Build outputs
+
+- `dist/` : static site (Vite output), deployed to GitHub Pages
+- `bin/cli.js` : CLI entry point (tsup output from `bin/cli.ts`)
+- `bin/kc-mocks.js` : npm package export for Keycloak mock definitions
+- `tools/preview-renderer/preview-renderer.jar` : Java JAR for FreeMarker rendering during preview generation
+
+## Tests
+
+Framework: Vitest (unit) + Playwright (E2E).
+
+Unit tests live next to source in `__tests__/` subdirectories. Currently 25 test files, ~160 tests. No React component tests exist yet.
+
+The single E2E smoke test (`e2e/smoke.test.ts`) loads the app and checks for JS errors. Playwright's `webServer` config starts `npm run dev` automatically.
+
+## CI
+
+GitHub Actions pipeline (`.github/workflows/pipeline.yml`): lint -> test -> build -> playwright. Runs on push to main and PRs. On push to main, also deploys to GitHub Pages.
+
+## Commit conventions
+
+Do not add `Co-Authored-By` lines.
+
+## Key files
+
+- `vite.config.ts` : Vite + React + static copy config
+- `src/main.tsx` : React entry point
+- `src/app/EditorContent.tsx` : main layout component
+- `tools/generate-preview.ts` : CLI tool to generate preview HTML (uses Java JAR + FreeMarker)
+- `tools/sync-keycloak.ts` : syncs Keycloak FreeMarker templates
+- `bin/cli.ts` : `keycloak-theme-editor` CLI (local development mode)

--- a/src/features/assets/__tests__/upload-service.test.ts
+++ b/src/features/assets/__tests__/upload-service.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { processUploadedFile, validateAssetFile } from '../upload-service'
+
+function makeFile(name: string, type: string, sizeBytes = 100): File {
+  return new File(['x'.repeat(sizeBytes)], name, { type })
+}
+
+beforeEach(() => {
+  URL.createObjectURL = vi.fn(() => 'blob:mock')
+  URL.revokeObjectURL = vi.fn()
+
+  vi.stubGlobal('Image', class {
+    width = 100
+    height = 50
+    private _onload: (() => void) | null = null
+    private _src = ''
+
+    get onload() { return this._onload }
+    set onload(fn: (() => void) | null) { this._onload = fn }
+
+    get src() { return this._src }
+    set src(value: string) {
+      this._src = value
+      setTimeout(() => this._onload?.(), 0)
+    }
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('validateAssetFile', () => {
+  describe('size limit', () => {
+    it('rejects files over 5 MB', () => {
+      const file = makeFile('big.png', 'image/png', 5 * 1024 * 1024 + 1)
+      expect(validateAssetFile(file, 'background')).toMatch(/5MB/)
+    })
+
+    it('accepts files at exactly 5 MB', () => {
+      const file = makeFile('exact.png', 'image/png', 5 * 1024 * 1024)
+      expect(validateAssetFile(file, 'background')).toBeNull()
+    })
+  })
+
+  describe('image categories', () => {
+    it.each(['background', 'logo', 'favicon', 'image'] as const)(
+      'accepts PNG for %s',
+      (category) => {
+        expect(validateAssetFile(makeFile('img.png', 'image/png'), category)).toBeNull()
+      },
+    )
+
+    it('accepts JPEG by MIME type', () => {
+      expect(validateAssetFile(makeFile('img.jpg', 'image/jpeg'), 'logo')).toBeNull()
+    })
+
+    it('accepts SVG by MIME type', () => {
+      expect(validateAssetFile(makeFile('img.svg', 'image/svg+xml'), 'logo')).toBeNull()
+    })
+
+    it('accepts WebP by MIME type', () => {
+      expect(validateAssetFile(makeFile('img.webp', 'image/webp'), 'image')).toBeNull()
+    })
+
+    it('accepts ICO by MIME type', () => {
+      expect(validateAssetFile(makeFile('img.ico', 'image/x-icon'), 'favicon')).toBeNull()
+    })
+
+    it('falls back to extension when MIME type is empty', () => {
+      expect(validateAssetFile(makeFile('photo.png', ''), 'background')).toBeNull()
+    })
+
+    it('rejects unsupported image type', () => {
+      expect(validateAssetFile(makeFile('img.bmp', 'image/bmp'), 'background')).toMatch(/Invalid image/)
+    })
+
+    it('rejects font file uploaded to image category', () => {
+      expect(validateAssetFile(makeFile('font.woff2', 'font/woff2'), 'logo')).toMatch(/Invalid image/)
+    })
+  })
+
+  describe('font category', () => {
+    it('accepts WOFF2 by MIME type', () => {
+      expect(validateAssetFile(makeFile('font.woff2', 'font/woff2'), 'font')).toBeNull()
+    })
+
+    it('accepts TTF by MIME type', () => {
+      expect(validateAssetFile(makeFile('font.ttf', 'font/ttf'), 'font')).toBeNull()
+    })
+
+    it('accepts OTF by MIME type', () => {
+      expect(validateAssetFile(makeFile('font.otf', 'font/otf'), 'font')).toBeNull()
+    })
+
+    it('falls back to extension when MIME type is empty', () => {
+      expect(validateAssetFile(makeFile('font.woff2', ''), 'font')).toBeNull()
+    })
+
+    it('rejects unsupported font type', () => {
+      expect(validateAssetFile(makeFile('font.mp3', 'audio/mpeg'), 'font')).toMatch(/Invalid font/)
+    })
+
+    it('rejects image file uploaded to font category', () => {
+      expect(validateAssetFile(makeFile('img.png', 'image/png'), 'font')).toMatch(/Invalid font/)
+    })
+  })
+})
+
+describe('processUploadedFile', () => {
+  it('returns the correct base structure', async () => {
+    const file = makeFile('img.png', 'image/png')
+    const asset = await processUploadedFile(file, 'image')
+
+    expect(asset.id).toMatch(/^asset-/)
+    expect(asset.name).toBe('img.png')
+    expect(asset.category).toBe('image')
+    expect(asset.mimeType).toBe('image/png')
+    expect(asset.size).toBe(file.size)
+    expect(asset.base64Data).toBeTruthy()
+    expect(typeof asset.createdAt).toBe('number')
+  })
+
+  it('falls back to extension-based MIME type when file.type is empty', async () => {
+    const asset = await processUploadedFile(makeFile('img.png', ''), 'background')
+    expect(asset.mimeType).toBe('image/png')
+  })
+
+  describe('font metadata', () => {
+    it('adds fontFamily, fontWeight, fontStyle for font category', async () => {
+      const asset = await processUploadedFile(makeFile('MyFont.woff2', 'font/woff2'), 'font')
+      expect(asset.fontFamily).toBe('MyFont')
+      expect(asset.fontWeight).toBe('400')
+      expect(asset.fontStyle).toBe('normal')
+    })
+
+    it('derives font family from hyphenated filename', async () => {
+      const asset = await processUploadedFile(makeFile('open-sans-regular.ttf', 'font/ttf'), 'font')
+      expect(asset.fontFamily).toBe('Open Sans Regular')
+    })
+
+    it('does not add font metadata for image category', async () => {
+      const asset = await processUploadedFile(makeFile('img.png', 'image/png'), 'image')
+      expect(asset.fontFamily).toBeUndefined()
+      expect(asset.fontWeight).toBeUndefined()
+    })
+  })
+
+  describe('image dimensions', () => {
+    it('reads dimensions for background', async () => {
+      const asset = await processUploadedFile(makeFile('bg.png', 'image/png'), 'background')
+      expect(asset.width).toBe(100)
+      expect(asset.height).toBe(50)
+    })
+
+    it('reads dimensions for logo', async () => {
+      const asset = await processUploadedFile(makeFile('logo.svg', 'image/svg+xml'), 'logo')
+      expect(asset.width).toBe(100)
+      expect(asset.height).toBe(50)
+    })
+
+    it('does not add dimensions for font category', async () => {
+      const asset = await processUploadedFile(makeFile('font.woff2', 'font/woff2'), 'font')
+      expect(asset.width).toBeUndefined()
+      expect(asset.height).toBeUndefined()
+    })
+
+    it('continues without dimensions if image load fails', async () => {
+      vi.stubGlobal('Image', class {
+        private _onerror: (() => void) | null = null
+        private _src = ''
+
+        get onerror() { return this._onerror }
+        set onerror(fn: (() => void) | null) { this._onerror = fn }
+
+        get src() { return this._src }
+        set src(value: string) {
+          this._src = value
+          if (this._onerror)
+            setTimeout(this._onerror, 0)
+        }
+      })
+
+      const asset = await processUploadedFile(makeFile('broken.png', 'image/png'), 'background')
+      expect(asset.width).toBeUndefined()
+      expect(asset.height).toBeUndefined()
+      expect(asset.base64Data).toBeTruthy()
+    })
+  })
+})

--- a/src/features/assets/__tests__/upload-service.test.ts
+++ b/src/features/assets/__tests__/upload-service.test.ts
@@ -6,8 +6,8 @@ function makeFile(name: string, type: string, sizeBytes = 100): File {
 }
 
 beforeEach(() => {
-  URL.createObjectURL = vi.fn(() => 'blob:mock')
-  URL.revokeObjectURL = vi.fn()
+  vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock')
+  vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
 
   vi.stubGlobal('Image', class {
     width = 100
@@ -27,6 +27,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  vi.restoreAllMocks()
   vi.unstubAllGlobals()
 })
 

--- a/src/features/editor/__tests__/asset-actions.test.ts
+++ b/src/features/editor/__tests__/asset-actions.test.ts
@@ -1,0 +1,274 @@
+import type { UploadedAsset } from '../../assets/types'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { assetActions } from '../actions/asset-actions'
+import { historyActions, subscribeToScopeChanges } from '../actions/history-actions'
+import { assetStore } from '../stores/asset-store'
+import { historyStore } from '../stores/history-store'
+import { presetStore } from '../stores/preset-store'
+
+function makeAsset(overrides: Partial<UploadedAsset> = {}): UploadedAsset {
+  return {
+    id: 'asset-1',
+    name: 'test.png',
+    category: 'image',
+    mimeType: 'image/png',
+    base64Data: 'abc123',
+    size: 100,
+    createdAt: 0,
+    ...overrides,
+  }
+}
+
+function resetStores() {
+  assetStore.setState(() => ({
+    uploadedAssets: [],
+    appliedAssets: {},
+    appliedAssetsByTheme: {},
+  }))
+  historyStore.setState(() => ({
+    activeScopeKey: 'v2::light',
+    stacksByScope: {},
+    undoStack: [],
+    redoStack: [],
+    canUndo: false,
+    canRedo: false,
+    revision: 0,
+  }))
+  presetStore.setState(state => ({ ...state, selectedThemeId: 'v2' }))
+}
+
+describe('assetActions', () => {
+  let unsubscribe: () => void
+
+  beforeEach(() => {
+    unsubscribe = subscribeToScopeChanges()
+    resetStores()
+  })
+
+  afterEach(() => {
+    unsubscribe?.()
+  })
+
+  describe('addUploadedAsset', () => {
+    it('appends to uploadedAssets for multi-asset category (image)', () => {
+      assetActions.addUploadedAsset(makeAsset({ id: 'a', category: 'image' }))
+      assetActions.addUploadedAsset(makeAsset({ id: 'b', category: 'image' }))
+      expect(assetStore.getState().uploadedAssets).toHaveLength(2)
+    })
+
+    it('appends to uploadedAssets for multi-asset category (font)', () => {
+      assetActions.addUploadedAsset(makeAsset({ id: 'a', category: 'font' }))
+      assetActions.addUploadedAsset(makeAsset({ id: 'b', category: 'font' }))
+      expect(assetStore.getState().uploadedAssets).toHaveLength(2)
+    })
+
+    it('replaces non-default asset for single-asset category (background)', () => {
+      assetActions.addUploadedAsset(makeAsset({ id: 'old', category: 'background' }))
+      assetActions.addUploadedAsset(makeAsset({ id: 'new', category: 'background' }))
+      const ids = assetStore.getState().uploadedAssets.map(a => a.id)
+      expect(ids).toEqual(['new'])
+    })
+
+    it('keeps default asset when uploading replacement for single-asset category', () => {
+      assetStore.setState(s => ({
+        ...s,
+        uploadedAssets: [makeAsset({ id: 'default-bg', category: 'background', isDefault: true })],
+      }))
+      assetActions.addUploadedAsset(makeAsset({ id: 'custom', category: 'background' }))
+      const ids = assetStore.getState().uploadedAssets.map(a => a.id)
+      expect(ids).toContain('default-bg')
+      expect(ids).toContain('custom')
+    })
+
+    it('auto-applies background asset', () => {
+      assetActions.addUploadedAsset(makeAsset({ id: 'bg1', category: 'background' }))
+      expect(assetStore.getState().appliedAssets.background).toBe('bg1')
+    })
+
+    it('auto-applies logo asset', () => {
+      assetActions.addUploadedAsset(makeAsset({ id: 'logo1', category: 'logo' }))
+      expect(assetStore.getState().appliedAssets.logo).toBe('logo1')
+    })
+
+    it('auto-applies favicon asset', () => {
+      assetActions.addUploadedAsset(makeAsset({ id: 'fav1', category: 'favicon' }))
+      expect(assetStore.getState().appliedAssets.favicon).toBe('fav1')
+    })
+
+    it('does not auto-apply font or image category', () => {
+      assetActions.addUploadedAsset(makeAsset({ id: 'f1', category: 'font' }))
+      assetActions.addUploadedAsset(makeAsset({ id: 'i1', category: 'image' }))
+      expect(assetStore.getState().appliedAssets.bodyFont).toBeUndefined()
+    })
+
+    it('stores applied asset scoped to active theme', () => {
+      assetActions.addUploadedAsset(makeAsset({ id: 'bg1', category: 'background' }))
+      expect(assetStore.getState().appliedAssetsByTheme.v2?.background).toBe('bg1')
+    })
+
+    it('registers undo action', () => {
+      assetActions.addUploadedAsset(makeAsset())
+      expect(historyStore.getState().undoStack).toHaveLength(1)
+    })
+
+    it('undo removes added asset', () => {
+      assetActions.addUploadedAsset(makeAsset({ id: 'a' }))
+      historyActions.undo()
+      expect(assetStore.getState().uploadedAssets).toHaveLength(0)
+    })
+
+    it('undo restores previous appliedAssets', () => {
+      assetStore.setState(s => ({ ...s, appliedAssets: { logo: 'existing' } }))
+      assetActions.addUploadedAsset(makeAsset({ id: 'bg1', category: 'background' }))
+      historyActions.undo()
+      expect(assetStore.getState().appliedAssets.background).toBeUndefined()
+      expect(assetStore.getState().appliedAssets.logo).toBe('existing')
+    })
+  })
+
+  describe('removeUploadedAsset', () => {
+    it('removes asset by id', () => {
+      assetStore.setState(s => ({ ...s, uploadedAssets: [makeAsset({ id: 'a' })] }))
+      assetActions.removeUploadedAsset('a')
+      expect(assetStore.getState().uploadedAssets).toHaveLength(0)
+    })
+
+    it('does nothing for unknown id', () => {
+      assetStore.setState(s => ({ ...s, uploadedAssets: [makeAsset({ id: 'a' })] }))
+      assetActions.removeUploadedAsset('nonexistent')
+      expect(assetStore.getState().uploadedAssets).toHaveLength(1)
+      expect(historyStore.getState().undoStack).toHaveLength(0)
+    })
+
+    it('clears applied background when removing the applied background asset', () => {
+      assetStore.setState(s => ({
+        ...s,
+        uploadedAssets: [makeAsset({ id: 'bg', category: 'background' })],
+        appliedAssets: { background: 'bg' },
+      }))
+      assetActions.removeUploadedAsset('bg')
+      expect(assetStore.getState().appliedAssets.background).toBeUndefined()
+    })
+
+    it('does not clear background when removing a non-applied background asset', () => {
+      assetStore.setState(s => ({
+        ...s,
+        uploadedAssets: [
+          makeAsset({ id: 'bg1', category: 'background' }),
+          makeAsset({ id: 'bg2', category: 'background' }),
+        ],
+        appliedAssets: { background: 'bg1' },
+      }))
+      assetActions.removeUploadedAsset('bg2')
+      expect(assetStore.getState().appliedAssets.background).toBe('bg1')
+    })
+
+    it('clears applied bodyFont when removing the applied font', () => {
+      assetStore.setState(s => ({
+        ...s,
+        uploadedAssets: [makeAsset({ id: 'f1', category: 'font' })],
+        appliedAssets: { bodyFont: 'f1' },
+      }))
+      assetActions.removeUploadedAsset('f1')
+      expect(assetStore.getState().appliedAssets.bodyFont).toBeUndefined()
+    })
+
+    it('clears applied favicon when removing the applied favicon', () => {
+      assetStore.setState(s => ({
+        ...s,
+        uploadedAssets: [makeAsset({ id: 'fav', category: 'favicon' })],
+        appliedAssets: { favicon: 'fav' },
+      }))
+      assetActions.removeUploadedAsset('fav')
+      expect(assetStore.getState().appliedAssets.favicon).toBeUndefined()
+    })
+
+    it('registers undo action', () => {
+      assetStore.setState(s => ({ ...s, uploadedAssets: [makeAsset({ id: 'a' })] }))
+      assetActions.removeUploadedAsset('a')
+      expect(historyStore.getState().undoStack).toHaveLength(1)
+    })
+
+    it('undo restores removed asset', () => {
+      const asset = makeAsset({ id: 'a' })
+      assetStore.setState(s => ({ ...s, uploadedAssets: [asset] }))
+      assetActions.removeUploadedAsset('a')
+      historyActions.undo()
+      expect(assetStore.getState().uploadedAssets[0].id).toBe('a')
+    })
+
+    it('undo restores cleared appliedAssets', () => {
+      assetStore.setState(s => ({
+        ...s,
+        uploadedAssets: [makeAsset({ id: 'bg', category: 'background' })],
+        appliedAssets: { background: 'bg' },
+      }))
+      assetActions.removeUploadedAsset('bg')
+      historyActions.undo()
+      expect(assetStore.getState().appliedAssets.background).toBe('bg')
+    })
+  })
+
+  describe('applyAsset', () => {
+    it('sets target in appliedAssets', () => {
+      assetActions.applyAsset('logo', 'logo1')
+      expect(assetStore.getState().appliedAssets.logo).toBe('logo1')
+    })
+
+    it('scopes applied asset to active theme', () => {
+      assetActions.applyAsset('background', 'bg1')
+      expect(assetStore.getState().appliedAssetsByTheme.v2?.background).toBe('bg1')
+    })
+
+    it('does nothing and skips history if asset already applied to target', () => {
+      assetStore.setState(s => ({ ...s, appliedAssets: { logo: 'logo1' } }))
+      assetActions.applyAsset('logo', 'logo1')
+      expect(historyStore.getState().undoStack).toHaveLength(0)
+    })
+
+    it('registers undo action', () => {
+      assetActions.applyAsset('logo', 'logo1')
+      expect(historyStore.getState().undoStack).toHaveLength(1)
+    })
+
+    it('undo restores previous applied state', () => {
+      assetStore.setState(s => ({ ...s, appliedAssets: { logo: 'old-logo' } }))
+      assetActions.applyAsset('logo', 'new-logo')
+      historyActions.undo()
+      expect(assetStore.getState().appliedAssets.logo).toBe('old-logo')
+    })
+
+    it('redo re-applies after undo', () => {
+      assetActions.applyAsset('logo', 'logo1')
+      historyActions.undo()
+      historyActions.redo()
+      expect(assetStore.getState().appliedAssets.logo).toBe('logo1')
+    })
+  })
+
+  describe('unapplyAsset', () => {
+    it('removes target from appliedAssets', () => {
+      assetStore.setState(s => ({ ...s, appliedAssets: { logo: 'logo1' } }))
+      assetActions.unapplyAsset('logo')
+      expect(assetStore.getState().appliedAssets.logo).toBeUndefined()
+    })
+
+    it('does nothing and skips history if target not applied', () => {
+      assetActions.unapplyAsset('logo')
+      expect(historyStore.getState().undoStack).toHaveLength(0)
+    })
+
+    it('registers undo action', () => {
+      assetStore.setState(s => ({ ...s, appliedAssets: { logo: 'logo1' } }))
+      assetActions.unapplyAsset('logo')
+      expect(historyStore.getState().undoStack).toHaveLength(1)
+    })
+
+    it('undo restores unapplied asset', () => {
+      assetStore.setState(s => ({ ...s, appliedAssets: { logo: 'logo1' } }))
+      assetActions.unapplyAsset('logo')
+      historyActions.undo()
+      expect(assetStore.getState().appliedAssets.logo).toBe('logo1')
+    })
+  })
+})


### PR DESCRIPTION
Part of #34 (Phase 1 of the test strategy).

## What

- `src/features/assets/__tests__/upload-service.test.ts` (23 tests)
  - `validateAssetFile`: size limit, all valid MIME types and extension fallback per category, rejection of wrong types
  - `processUploadedFile`: base structure, font metadata, image dimensions, graceful failure when image load fails

- `src/features/editor/__tests__/asset-actions.test.ts` (36 tests)
  - `addUploadedAsset`: multi vs. single category behavior, default asset protection, auto-apply, theme scoping, undo/redo
  - `removeUploadedAsset`: removal, selective clearing of appliedAssets, undo
  - `applyAsset`: setting target, idempotency, undo/redo
  - `unapplyAsset`: removal, idempotency, undo

- `CLAUDE.md`: codebase documentation for Claude Code

## Result

27 test files / 219 tests (up from 25 / 160).