### PR TITLE
Add timeout to playwright install step to prevent CI hangs

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,6 +21,7 @@ jobs:
       - run: npm run test
       - run: npm run build
       - run: npx playwright install --with-deps chromium
+        timeout-minutes: 10
       - run: npm run test:e2e
       - if: github.event_name == 'push'
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
The `playwright install --with-deps chromium` step has been hanging indefinitely on GitHub Actions runners (observed on PRs #28 and #32, stuck for 4+ hours each time). Adding `timeout-minutes: 10` causes the step to fail fast and retry rather than blocking the runner indefinitely.

Prerequisite for expanding E2E coverage (part of #34 Phase 3).