### PR TITLE
Add tests for import-actions, theme-validation and theme-file-assembler

### DIFF
--- a/src/features/editor/__tests__/import-actions.test.ts
+++ b/src/features/editor/__tests__/import-actions.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { importActions } from '../actions/import-actions'
+import { coreStore } from '../stores/core-store'
+import { presetStore } from '../stores/preset-store'
+
+function resetStores() {
+  coreStore.setState(s => ({ ...s, isDarkMode: false }))
+  presetStore.setState(s => ({
+    ...s,
+    showClientName: false,
+    showRealmName: false,
+    infoMessage: '',
+    imprintUrl: '',
+    dataProtectionUrl: '',
+  }))
+}
+
+describe('importActions.applyImportedQuickSettingsForPreset', () => {
+  beforeEach(resetStores)
+
+  it('does nothing when called with undefined', () => {
+    importActions.applyImportedQuickSettingsForPreset(undefined)
+    expect(presetStore.getState().showClientName).toBe(false)
+  })
+
+  it('does nothing when no mode-specific settings are present', () => {
+    importActions.applyImportedQuickSettingsForPreset({})
+    expect(presetStore.getState().showClientName).toBe(false)
+  })
+
+  it('applies light mode settings in light mode', () => {
+    importActions.applyImportedQuickSettingsForPreset({ light: { showClientName: true } })
+    expect(presetStore.getState().showClientName).toBe(true)
+  })
+
+  it('applies dark mode settings in dark mode', () => {
+    coreStore.setState(s => ({ ...s, isDarkMode: true }))
+    importActions.applyImportedQuickSettingsForPreset({ dark: { showClientName: true } })
+    expect(presetStore.getState().showClientName).toBe(true)
+  })
+
+  it('falls back to light settings when dark is absent in dark mode', () => {
+    coreStore.setState(s => ({ ...s, isDarkMode: true }))
+    importActions.applyImportedQuickSettingsForPreset({ light: { showClientName: true } })
+    expect(presetStore.getState().showClientName).toBe(true)
+  })
+
+  it('falls back to dark settings when light is absent in light mode', () => {
+    importActions.applyImportedQuickSettingsForPreset({ dark: { showClientName: true } })
+    expect(presetStore.getState().showClientName).toBe(true)
+  })
+
+  it('ignores undefined values and leaves existing state untouched', () => {
+    presetStore.setState(s => ({ ...s, infoMessage: 'existing' }))
+    importActions.applyImportedQuickSettingsForPreset({
+      light: { showClientName: true, infoMessage: undefined },
+    })
+    expect(presetStore.getState().showClientName).toBe(true)
+    expect(presetStore.getState().infoMessage).toBe('existing')
+  })
+
+  it('does nothing when all settings are undefined after filtering', () => {
+    importActions.applyImportedQuickSettingsForPreset({
+      light: { showClientName: undefined, infoMessage: undefined },
+    })
+    expect(presetStore.getState().showClientName).toBe(false)
+  })
+
+  it('applies all supported content fields', () => {
+    importActions.applyImportedQuickSettingsForPreset({
+      light: {
+        showClientName: true,
+        showRealmName: true,
+        infoMessage: 'Hello',
+        imprintUrl: 'https://example.com/imprint',
+        dataProtectionUrl: 'https://example.com/privacy',
+      },
+    })
+    const s = presetStore.getState()
+    expect(s.showClientName).toBe(true)
+    expect(s.showRealmName).toBe(true)
+    expect(s.infoMessage).toBe('Hello')
+    expect(s.imprintUrl).toBe('https://example.com/imprint')
+    expect(s.dataProtectionUrl).toBe('https://example.com/privacy')
+  })
+})

--- a/src/features/theme-export/__tests__/theme-file-assembler.test.ts
+++ b/src/features/theme-export/__tests__/theme-file-assembler.test.ts
@@ -1,0 +1,137 @@
+import type { AssembleThemeFilesParams, ThemeEditorMetadata } from '../types'
+import { describe, expect, it } from 'vitest'
+import { assembleThemeFiles, generateEditorMetadataJson, generateKeycloakThemesJson } from '../theme-file-assembler'
+
+const decoder = new TextDecoder()
+
+function decode(files: Record<string, Uint8Array>, path: string): string {
+  return decoder.decode(files[path])
+}
+
+function makeAsset(name: string, mimeType = 'image/png') {
+  return { id: name, name, category: 'image' as const, mimeType, base64Data: 'aGVsbG8=', size: 5, createdAt: 0 }
+}
+
+function makeParams(overrides?: Partial<AssembleThemeFilesParams>): AssembleThemeFilesParams {
+  return {
+    themeName: 'test-theme',
+    properties: 'parent=keycloak',
+    templateFtl: null,
+    footerFtl: null,
+    quickStartCss: '',
+    stylesCss: '.base {}',
+    messagesContent: '',
+    payload: {
+      generatedCss: '',
+      uploadedFonts: [],
+      uploadedBackgrounds: [],
+      uploadedLogos: [],
+      uploadedImages: [],
+      appliedFavicon: undefined,
+    },
+    editorMetadata: { sourceThemeId: 'keycloak/login' } as ThemeEditorMetadata,
+    ...overrides,
+  }
+}
+
+describe('generateKeycloakThemesJson', () => {
+  it('produces valid JSON with theme name and login type', () => {
+    const json = JSON.parse(generateKeycloakThemesJson('my-theme'))
+    expect(json).toEqual({ themes: [{ name: 'my-theme', types: ['login'] }] })
+  })
+})
+
+describe('generateEditorMetadataJson', () => {
+  it('serializes metadata to JSON', () => {
+    const meta = { sourceThemeId: 'keycloak/login' } as ThemeEditorMetadata
+    const json = JSON.parse(generateEditorMetadataJson(meta))
+    expect(json).toEqual(meta)
+  })
+})
+
+describe('assembleThemeFiles', () => {
+  const themeRoot = 'theme/test-theme'
+  const metaInf = 'META-INF/'
+  const loginRoot = `${themeRoot}/login`
+
+  it('includes theme.properties', async () => {
+    const files = await assembleThemeFiles(makeParams(), themeRoot, metaInf)
+    expect(decode(files, `${loginRoot}/theme.properties`)).toBe('parent=keycloak')
+  })
+
+  it('writes stylesCss to css/styles.css when no stylesCssFiles given', async () => {
+    const files = await assembleThemeFiles(makeParams({ stylesCss: '.single {}' }), themeRoot, metaInf)
+    expect(decode(files, `${loginRoot}/resources/css/styles.css`)).toBe('.single {}')
+  })
+
+  it('uses stylesCssFiles instead of stylesCss when provided', async () => {
+    const files = await assembleThemeFiles(
+      makeParams({ stylesCssFiles: { 'css/custom.css': '.custom {}', 'css/extra.css': '.extra {}' } }),
+      themeRoot,
+      metaInf,
+    )
+    expect(decode(files, `${loginRoot}/resources/css/custom.css`)).toBe('.custom {}')
+    expect(decode(files, `${loginRoot}/resources/css/extra.css`)).toBe('.extra {}')
+    expect(files[`${loginRoot}/resources/css/styles.css`]).toBeUndefined()
+  })
+
+  it('includes quickStartCss when provided', async () => {
+    const files = await assembleThemeFiles(makeParams({ quickStartCss: ':root {}' }), themeRoot, metaInf)
+    expect(decode(files, `${loginRoot}/resources/css/quick-start.css`)).toBe(':root {}')
+  })
+
+  it('omits quick-start.css when quickStartCss is empty', async () => {
+    const files = await assembleThemeFiles(makeParams({ quickStartCss: '' }), themeRoot, metaInf)
+    expect(files[`${loginRoot}/resources/css/quick-start.css`]).toBeUndefined()
+  })
+
+  it('includes templateFtl when provided', async () => {
+    const files = await assembleThemeFiles(makeParams({ templateFtl: '<html/>' }), themeRoot, metaInf)
+    expect(decode(files, `${loginRoot}/template.ftl`)).toBe('<html/>')
+  })
+
+  it('omits template.ftl when not provided', async () => {
+    const files = await assembleThemeFiles(makeParams({ templateFtl: null }), themeRoot, metaInf)
+    expect(files[`${loginRoot}/template.ftl`]).toBeUndefined()
+  })
+
+  it('includes footerFtl when provided', async () => {
+    const files = await assembleThemeFiles(makeParams({ footerFtl: '<footer/>' }), themeRoot, metaInf)
+    expect(decode(files, `${loginRoot}/footer.ftl`)).toBe('<footer/>')
+  })
+
+  it('includes customFtlFiles when provided', async () => {
+    const files = await assembleThemeFiles(
+      makeParams({ customFtlFiles: { 'login.ftl': '<login/>' } }),
+      themeRoot,
+      metaInf,
+    )
+    expect(decode(files, `${loginRoot}/login.ftl`)).toBe('<login/>')
+  })
+
+  it('places uploaded background in img/backgrounds/', async () => {
+    const bg = makeAsset('bg.png', 'image/png')
+    const params = makeParams({ payload: { ...makeParams().payload, uploadedBackgrounds: [bg] } })
+    const files = await assembleThemeFiles(params, themeRoot, metaInf)
+    expect(files[`${loginRoot}/resources/img/backgrounds/bg.png`]).toBeDefined()
+  })
+
+  it('deduplicates assets with the same name (last wins)', async () => {
+    const a1 = { ...makeAsset('logo.png'), base64Data: 'AAAA' }
+    const a2 = { ...makeAsset('logo.png'), base64Data: 'BBBB' }
+    const params = makeParams({ payload: { ...makeParams().payload, uploadedLogos: [a1, a2] } })
+    const files = await assembleThemeFiles(params, themeRoot, metaInf)
+    const content = files[`${loginRoot}/resources/img/logos/logo.png`]
+    expect(content).toBeDefined()
+    // Only one file should exist (deduped)
+    const logoKeys = Object.keys(files).filter(k => k.includes('img/logos'))
+    expect(logoKeys).toHaveLength(1)
+  })
+
+  it('places favicon at img/favicon.ico', async () => {
+    const fav = makeAsset('favicon.png', 'image/png')
+    const params = makeParams({ payload: { ...makeParams().payload, appliedFavicon: fav } })
+    const files = await assembleThemeFiles(params, themeRoot, metaInf)
+    expect(files[`${loginRoot}/resources/img/favicon.ico`]).toBeDefined()
+  })
+})

--- a/src/features/theme-export/__tests__/theme-file-assembler.test.ts
+++ b/src/features/theme-export/__tests__/theme-file-assembler.test.ts
@@ -16,7 +16,7 @@ function makeParams(overrides?: Partial<AssembleThemeFilesParams>): AssembleThem
   return {
     themeName: 'test-theme',
     properties: 'parent=keycloak',
-    templateFtl: null,
+    templateFtl: '',
     footerFtl: null,
     quickStartCss: '',
     stylesCss: '.base {}',
@@ -90,8 +90,8 @@ describe('assembleThemeFiles', () => {
     expect(decode(files, `${loginRoot}/template.ftl`)).toBe('<html/>')
   })
 
-  it('omits template.ftl when not provided', async () => {
-    const files = await assembleThemeFiles(makeParams({ templateFtl: null }), themeRoot, metaInf)
+  it('omits template.ftl when empty', async () => {
+    const files = await assembleThemeFiles(makeParams({ templateFtl: '' }), themeRoot, metaInf)
     expect(files[`${loginRoot}/template.ftl`]).toBeUndefined()
   })
 

--- a/src/features/theme-export/__tests__/theme-file-assembler.test.ts
+++ b/src/features/theme-export/__tests__/theme-file-assembler.test.ts
@@ -117,12 +117,11 @@ describe('assembleThemeFiles', () => {
   })
 
   it('deduplicates assets with the same name (last wins)', async () => {
-    const a1 = { ...makeAsset('logo.png'), base64Data: 'AAAA' }
-    const a2 = { ...makeAsset('logo.png'), base64Data: 'BBBB' }
+    const a1 = { ...makeAsset('logo.png'), base64Data: 'Zmlyc3Q=' }
+    const a2 = { ...makeAsset('logo.png'), base64Data: 'c2Vjb25k' }
     const params = makeParams({ payload: { ...makeParams().payload, uploadedLogos: [a1, a2] } })
     const files = await assembleThemeFiles(params, themeRoot, metaInf)
-    const content = files[`${loginRoot}/resources/img/logos/logo.png`]
-    expect(content).toBeDefined()
+    expect(decode(files, `${loginRoot}/resources/img/logos/logo.png`)).toBe('second')
     // Only one file should exist (deduped)
     const logoKeys = Object.keys(files).filter(k => k.includes('img/logos'))
     expect(logoKeys).toHaveLength(1)

--- a/src/features/theme-export/__tests__/theme-validation.test.ts
+++ b/src/features/theme-export/__tests__/theme-validation.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { getThemeNameError } from '../theme-validation'
+
+describe('getThemeNameError', () => {
+  it('returns error for empty string', () => {
+    expect(getThemeNameError('')).toBe('Theme name is required')
+  })
+
+  it('returns error for whitespace-only string', () => {
+    expect(getThemeNameError('   ')).toBe('Theme name is required')
+  })
+
+  it('accepts a simple name', () => {
+    expect(getThemeNameError('mytheme')).toBe('')
+  })
+
+  it('accepts letters and numbers', () => {
+    expect(getThemeNameError('theme1')).toBe('')
+  })
+
+  it('accepts hyphens', () => {
+    expect(getThemeNameError('my-theme')).toBe('')
+  })
+
+  it('accepts underscores', () => {
+    expect(getThemeNameError('my_theme')).toBe('')
+  })
+
+  it('rejects spaces', () => {
+    expect(getThemeNameError('my theme')).not.toBe('')
+  })
+
+  it('rejects dots', () => {
+    expect(getThemeNameError('my.theme')).not.toBe('')
+  })
+
+  it('rejects special characters', () => {
+    expect(getThemeNameError('theme@1!')).not.toBe('')
+  })
+})


### PR DESCRIPTION
Part of #34 (Phase 4 of the test strategy).

## What

- `src/features/editor/__tests__/import-actions.test.ts` (9 tests)
  - `applyImportedQuickSettingsForPreset`: no-op on undefined/empty, light/dark mode selection, fallback order, undefined-value filtering, all content fields

- `src/features/theme-export/__tests__/theme-validation.test.ts` (9 tests)
  - `getThemeNameError`: empty, whitespace, valid names (letters/numbers/hyphens/underscores), invalid names (spaces/dots/special chars)

- `src/features/theme-export/__tests__/theme-file-assembler.test.ts` (14 tests)
  - `generateKeycloakThemesJson` and `generateEditorMetadataJson` as pure functions
  - `assembleThemeFiles`: theme.properties, single CSS file, multiple CSS files via `stylesCssFiles`, quick-start.css inclusion/omission, template/footer FTL, custom FTL files, asset buckets, asset deduplication by name, favicon placement

## Result

28 test files / 192 tests on this branch (up from 25 / 160 on main).