### PR TITLE
Add E2E happy path workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules
 dist
+test-results/
+playwright-report/
 
 bin/.preview-*/
 bin/*.js

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,16 @@
+# E2E Test Shape
+
+E2E tests should cover user workflows that unit tests cannot prove: browser file upload, preview iframe updates, downloads, and UI wiring across panels or dialogs.
+
+Keep specs grouped by workflow:
+
+- `smoke.test.ts`: app boots without runtime errors.
+- `quick-settings.test.ts`: quick-start controls update preview/export-facing state.
+- `export.test.ts`: downloadable Keycloak artifacts have the expected deployable shape.
+- `upload-assets.test.ts`: browser uploads affect preview and exported files.
+- `import-roundtrip.test.ts`: exported/imported JARs restore editor state.
+- future `cli.test.ts`: packaged CLI discovers and serves local themes.
+
+Helpers should stay mechanical. Put navigation and browser quirks in `helpers/`, but keep product assertions in the spec files so tests remain readable.
+
+Avoid testing incidental markup. Prefer accessible controls for user actions, preview iframe CSS/content for visible behavior, and downloaded archive contents for export correctness.

--- a/e2e/export.test.ts
+++ b/e2e/export.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test'
+import { openApp, prepareAppTest } from './helpers/app'
+import { downloadJar, readZipText } from './helpers/export'
+
+test.beforeEach(async ({ page }) => {
+  await prepareAppTest(page)
+})
+
+test('exports a deployable JAR with Keycloak metadata and generated quick-start CSS', async ({ page }) => {
+  await openApp(page)
+  await page.getByLabel('Primary color value').fill('#13579b')
+
+  const files = await downloadJar(page, 'e2e-theme')
+
+  expect(JSON.parse(readZipText(files, 'META-INF/keycloak-themes.json'))).toEqual({
+    themes: [{ name: 'e2e-theme', types: ['login'] }],
+  })
+  expect(readZipText(files, 'theme/e2e-theme/login/theme.properties')).toContain('styles=')
+  expect(readZipText(files, 'theme/e2e-theme/login/resources/css/quick-start.css')).toContain('#13579b')
+  expect(readZipText(files, 'theme/e2e-theme/login/messages/messages_en.properties')).toContain('imprintLabel=Imprint')
+})

--- a/e2e/helpers/app.ts
+++ b/e2e/helpers/app.ts
@@ -1,0 +1,32 @@
+import type { Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+
+export async function prepareAppTest(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.clear()
+    delete (window as Window & { showSaveFilePicker?: unknown }).showSaveFilePicker
+    delete (window as Window & { showDirectoryPicker?: unknown }).showDirectoryPicker
+  })
+}
+
+export async function openApp(page: Page) {
+  await page.goto('/')
+  await expect(page.locator('#root')).not.toBeEmpty()
+  await expect(page.getByRole('button', { name: 'Open editor menu' })).toBeVisible()
+  await expect(page.locator('iframe')).toBeVisible()
+}
+
+export async function openTopbarMenuItem(page: Page, name: string) {
+  await page.getByRole('button', { name: 'Open editor menu' }).click()
+  await page.getByRole('menuitem', { name }).click()
+}
+
+export async function openExportDialog(page: Page) {
+  await openTopbarMenuItem(page, 'Export theme')
+  await expect(page.getByRole('dialog', { name: 'Export Theme' })).toBeVisible()
+}
+
+export async function openImportDialog(page: Page) {
+  await openTopbarMenuItem(page, 'Import theme')
+  await expect(page.getByRole('dialog', { name: 'Import Theme' })).toBeVisible()
+}

--- a/e2e/helpers/export.ts
+++ b/e2e/helpers/export.ts
@@ -1,0 +1,44 @@
+import type { Page } from '@playwright/test'
+import { readFile } from 'node:fs/promises'
+import { expect } from '@playwright/test'
+import { unzipSync } from 'fflate'
+import { openExportDialog } from './app'
+
+export type ZipFiles = Record<string, Uint8Array>
+
+export interface DownloadedJar {
+  bytes: Uint8Array
+  files: ZipFiles
+}
+
+export async function downloadJarArchive(page: Page, themeName: string): Promise<DownloadedJar> {
+  await openExportDialog(page)
+  await page.locator('#theme-name-input').fill(themeName)
+
+  const downloadPromise = page.waitForEvent('download')
+  await page.getByRole('button', { name: new RegExp(`Download\\s+${themeName}\\.jar`) }).click()
+  const download = await downloadPromise
+  const path = await download.path()
+  expect(path).toBeTruthy()
+
+  const bytes = await readFile(path!)
+  const archiveBytes = new Uint8Array(bytes)
+  return {
+    bytes: archiveBytes,
+    files: unzipSync(archiveBytes),
+  }
+}
+
+export async function downloadJar(page: Page, themeName: string): Promise<ZipFiles> {
+  return (await downloadJarArchive(page, themeName)).files
+}
+
+export function expectZipEntry(files: ZipFiles, path: string): Uint8Array {
+  const entry = files[path]
+  expect(entry, `Expected ${path} in downloaded archive`).toBeTruthy()
+  return entry
+}
+
+export function readZipText(files: ZipFiles, path: string): string {
+  return new TextDecoder().decode(expectZipEntry(files, path))
+}

--- a/e2e/helpers/fixtures.ts
+++ b/e2e/helpers/fixtures.ts
@@ -1,0 +1,4 @@
+export const svgLogo = `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="32" viewBox="0 0 64 32">
+  <rect width="64" height="32" fill="#13579b"/>
+  <text x="8" y="21" fill="#fff" font-family="Arial" font-size="12">E2E</text>
+</svg>`

--- a/e2e/helpers/preview.ts
+++ b/e2e/helpers/preview.ts
@@ -1,0 +1,16 @@
+import type { Frame, Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+
+export async function getPreviewFrame(page: Page): Promise<Frame> {
+  const frameHandle = await page.locator('iframe').elementHandle()
+  const frame = await frameHandle?.contentFrame()
+  expect(frame).toBeTruthy()
+  await expect(frame!.locator('body')).toHaveAttribute('data-page-id', /login-/)
+  return frame!
+}
+
+export async function expectPreviewStyleToContain(frame: Frame, selector: string, text: string) {
+  await expect.poll(async () => {
+    return await frame.locator(selector).evaluate(element => element.textContent || '')
+  }).toContain(text)
+}

--- a/e2e/import-roundtrip.test.ts
+++ b/e2e/import-roundtrip.test.ts
@@ -1,0 +1,31 @@
+import { Buffer } from 'node:buffer'
+import { expect, test } from '@playwright/test'
+import { openApp, openImportDialog, prepareAppTest } from './helpers/app'
+import { downloadJarArchive } from './helpers/export'
+import { expectPreviewStyleToContain, getPreviewFrame } from './helpers/preview'
+
+test.beforeEach(async ({ page }) => {
+  await prepareAppTest(page)
+})
+
+test('imports a previously exported JAR and restores quick-start settings', async ({ page }) => {
+  await openApp(page)
+  await page.getByLabel('Primary color value').fill('#2468ac')
+
+  const exported = await downloadJarArchive(page, 'e2e-roundtrip-theme')
+
+  await page.reload()
+  await openApp(page)
+  await openImportDialog(page)
+  const importDialog = page.getByRole('dialog', { name: 'Import Theme' })
+  await importDialog.locator('input[type="file"]').setInputFiles({
+    name: 'e2e-roundtrip-theme.jar',
+    mimeType: 'application/java-archive',
+    buffer: Buffer.from(exported.bytes),
+  })
+  await page.getByRole('button', { name: 'Import JAR Theme' }).click()
+
+  await expect(page.getByText('Imported theme: e2e-roundtrip-theme')).toBeVisible()
+  const frame = await getPreviewFrame(page)
+  await expectPreviewStyleToContain(frame, '#preview-quick-start-overrides', '--quickstart-primary-color-light: #2468ac')
+})

--- a/e2e/quick-settings.test.ts
+++ b/e2e/quick-settings.test.ts
@@ -1,0 +1,18 @@
+import { test } from '@playwright/test'
+import { openApp, prepareAppTest } from './helpers/app'
+import { expectPreviewStyleToContain, getPreviewFrame } from './helpers/preview'
+
+test.beforeEach(async ({ page }) => {
+  await prepareAppTest(page)
+})
+
+test('background color updates the preview iframe', async ({ page }) => {
+  await openApp(page)
+  const frame = await getPreviewFrame(page)
+
+  await page.getByLabel('Background color value').fill('#123456')
+
+  await expectPreviewStyleToContain(frame, '#preview-quick-start-overrides', '--quickstart-bg-color-light: #123456')
+  await expectPreviewStyleToContain(frame, '#preview-quick-start-overrides', '--quickstart-bg-color: var(--quickstart-bg-color-light)')
+  await expectPreviewStyleToContain(frame, '#preview-quick-start-overrides', '--quickstart-bg-image: none')
+})

--- a/e2e/upload-assets.test.ts
+++ b/e2e/upload-assets.test.ts
@@ -1,0 +1,30 @@
+import { Buffer } from 'node:buffer'
+import { expect, test } from '@playwright/test'
+import { openApp, prepareAppTest } from './helpers/app'
+import { downloadJar, expectZipEntry, readZipText } from './helpers/export'
+import { svgLogo } from './helpers/fixtures'
+import { expectPreviewStyleToContain, getPreviewFrame } from './helpers/preview'
+
+test.beforeEach(async ({ page }) => {
+  await prepareAppTest(page)
+})
+
+test('uploads a logo and includes it in the exported JAR', async ({ page }) => {
+  await openApp(page)
+  await page.getByRole('tab', { name: 'Uploads' }).click()
+
+  await page.locator('input[type="file"]').nth(1).setInputFiles({
+    name: 'e2e-logo.svg',
+    mimeType: 'image/svg+xml',
+    buffer: Buffer.from(svgLogo),
+  })
+
+  const frame = await getPreviewFrame(page)
+  await expectPreviewStyleToContain(frame, '#preview-uploaded-images', '--uploaded-logo-e2e-logo')
+  await expectPreviewStyleToContain(frame, '#preview-applied-assets', '--quickstart-logo-url')
+
+  const files = await downloadJar(page, 'e2e-upload-theme')
+
+  expectZipEntry(files, 'theme/e2e-upload-theme/login/resources/img/logos/e2e-logo.svg')
+  expect(readZipText(files, 'theme/e2e-upload-theme/login/resources/css/styles.css')).toContain('../img/logos/e2e-logo.svg')
+})


### PR DESCRIPTION
Part of #34 Phase 3.

## What
- Adds E2E helpers for app navigation, preview iframe assertions, and JAR download inspection.
- Covers quick settings -> preview CSS, deployable JAR export, uploaded logo export, and exported JAR import round trip.
- Ignores Playwright generated output so local test artifacts do not enter lint/status noise.

## Base
Stacked on #37 (`fix/playwright-install-timeout`) because #34 lists that CI timeout fix as the Phase 3 prerequisite.

## Validation
- `npm run test:e2e` passed: 5 Chromium tests.