### PR TITLE
Add publish artifact checks to CI

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -16,10 +16,17 @@ jobs:
         with:
           node-version: 24
           cache: npm
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
       - run: npm ci
       - run: npm run lint
       - run: npm run test
       - run: npm run build
+      - run: npm run build:jar
+      - run: npm run build:cli
+      - run: npm pack --dry-run
       - run: npx playwright install --with-deps chromium
         timeout-minutes: 10
       - run: npm run test:e2e

--- a/tools/preview-renderer/pom.xml
+++ b/tools/preview-renderer/pom.xml
@@ -35,6 +35,21 @@
         <version>3.15.0</version>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.5.0</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>${project.basedir}/lib</directory>
+              <includes>
+                <include>*.jar</include>
+              </includes>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>3.6.3</version>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "ignoreDeprecations": "6.0"
+  },
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
         {
           src: 'docs/presentation/introduction/**/*',
           dest: 'docs/presentation/introduction',
+          rename: { stripBase: 3 },
         },
       ],
     }),


### PR DESCRIPTION
Publish correctness follow-up.

## What
- Adds Java setup and publish artifact gates to CI: `build:jar`, `build:cli`, and `npm pack --dry-run`.
- Cleans stale copied renderer dependency jars during Maven `clean`.
- Fixes Vite static-copy config so docs land at `dist/docs/presentation/introduction/*` without duplicating the source path.

## Why
Local package inspection found stale renderer jars and duplicated docs paths could slip through SPA-only CI. This makes the pipeline check the same artifacts we rely on before npm publish.

## Base
Stacked on #37 (`fix/playwright-install-timeout`) because this branch keeps the existing Playwright timeout prerequisite while adding publish gates.

## Validation
- `npm run build`
- `npm run build:jar`
- `npm run build:cli`
- `npm pack --dry-run`